### PR TITLE
Do not convert method to lower case in iOS

### DIFF
--- a/RNPinch/RNPinch.m
+++ b/RNPinch/RNPinch.m
@@ -91,7 +91,7 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
     NSURLSession *session;
     if (obj) {
         if (obj[@"method"]) {
-            [request setHTTPMethod:[obj[@"method"] lowercaseString]];
+            [request setHTTPMethod:obj[@"method"]];
         }
         if (obj[@"timeoutInterval"]) {
           [request setTimeoutInterval:[obj[@"timeoutInterval"] doubleValue] / 1000];


### PR DESCRIPTION
react-native-pinch converts the method attribute to lower case in iOS, but not in android.  I don't believe this is correct behaviour.  This was causing an issue for us where PATCH was not recognised because the check was case sensitive.