### PR TITLE
Change encoding from UTF8 to ISO Latin 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ Carthage/Build
 tsConfig.json
 
 android/.idea/
+.idea

--- a/RNPinch/RNPinch.m
+++ b/RNPinch/RNPinch.m
@@ -122,7 +122,7 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
             dispatch_async(dispatch_get_main_queue(), ^{
                 NSHTTPURLResponse *httpResp = (NSHTTPURLResponse*) response;
                 NSInteger statusCode = httpResp.statusCode;
-                NSString *bodyString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+                NSString *bodyString = [[NSString alloc] initWithData:data encoding:NSISOLatin1StringEncoding];
 
                 NSDictionary *res = @{
                                       @"status": @(statusCode),


### PR DESCRIPTION
Was causing iOS apps to crash when special characters were present in a response. Have updated the encoding type to include special characters.