### PR TITLE
Conform to documented response format in ios.

### DIFF
--- a/RNPinch/RNPinch.m
+++ b/RNPinch/RNPinch.m
@@ -123,11 +123,13 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
                 NSHTTPURLResponse *httpResp = (NSHTTPURLResponse*) response;
                 NSInteger statusCode = httpResp.statusCode;
                 NSString *bodyString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+                NSString *statusText = [NSHTTPURLResponse localizedStringForStatusCode:httpResponse.statusCode];
 
                 NSDictionary *res = @{
                                       @"status": @(statusCode),
                                       @"headers": httpResp.allHeaderFields,
-                                      @"bodyString": bodyString
+                                      @"bodyString": bodyString,
+                                      @"statusText": statusText
                                       };
                 callback(@[[NSNull null], res]);
             });


### PR DESCRIPTION
This adds a property to the iOS response object so that it conforms to the documented schema: https://github.com/localz/react-native-pinch#response-schema.