### PR TITLE
Add support for specifying multiple certificates from JS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,10 @@ pinch.fetch('https://my-api.com/v1/endpoint', {
   method: 'post',
   headers: { customHeader: 'customValue' },
   body: '{"firstName": "Jake", "lastName": "Moxey"}',
+  timeoutInterval: 10000 // timeout after 10 seconds
   sslPinning: {
-    cert: 'my-cool-cert'
+    cert: 'cert-file-name', // cert file name without the `.cer`
+    certs: ['cert-file-name-1', 'cert-file-name-2'], // optionally specify multiple certificates
   }
 })
   .then(res => console.log(`We got your response! Response - ${res}`))
@@ -146,7 +148,8 @@ pinch.fetch('https://my-api.com/v1/endpoint', {
   body: '{"firstName": "Jake", "lastName": "Moxey"}',
   timeoutInterval: 10000 // timeout after 10 seconds
   sslPinning: {
-    cert: 'my-cool-cert'
+    cert: 'cert-file-name', // cert file name without the `.cer`
+    certs: ['cert-file-name-1', 'cert-file-name-2'], // optionally specify multiple certificates
   }
 }, (err, res) => {
   if (err) {
@@ -154,6 +157,20 @@ pinch.fetch('https://my-api.com/v1/endpoint', {
     return null;
   }
   console.log(`We got your response! Response - ${res}`);
+})
+```
+
+### Skipping validation
+
+```javascript
+import pinch from 'react-native-pinch';
+
+pinch.fetch('https://my-api.com/v1/endpoint', {
+  method: 'post',
+  headers: { customHeader: 'customValue' },
+  body: '{"firstName": "Jake", "lastName": "Moxey"}',
+  timeoutInterval: 10000 // timeout after 10 seconds
+  sslPinning: {} // omit the `cert` or `certs` key, `sslPinning` can be ommited as well
 })
 ```
 

--- a/RNPinch/RNPinch.m
+++ b/RNPinch/RNPinch.m
@@ -9,29 +9,33 @@
 #import "RNPinch.h"
 #import "RCTBridge.h"
 
+// private delegate for verifying certs
 @interface NSURLSessionSSLPinningDelegate:NSObject <NSURLSessionDelegate>
 
-- (id)initWithCertName:(NSString *)certName;
+- (id)initWithCertNames:(NSArray<NSString *> *)certNames;
 
-@property (nonatomic, strong) NSString *certName;
+@property (nonatomic, strong) NSArray<NSString *> *certNames;
 
 @end
 
 @implementation NSURLSessionSSLPinningDelegate
 
-- (id)initWithCertName:(NSString *)certName {
+- (id)initWithCertNames:(NSArray<NSString *> *)certNames {
     if (self = [super init]) {
-        _certName = certName;
+        _certNames = certNames;
     }
     return self;
 }
 
 - (NSArray *)pinnedCertificateData {
-    NSString *cerPath = [[NSBundle mainBundle] pathForResource:self.certName ofType:@"cer"];
-    NSData *localCertData = [NSData dataWithContentsOfFile:cerPath];
+    NSMutableArray *localCertData = [NSMutableArray array];
+    for (NSString* certName in self.certNames) {
+        NSString *cerPath = [[NSBundle mainBundle] pathForResource:certName ofType:@"cer"];
+        [localCertData addObject:[NSData dataWithContentsOfFile:cerPath]];
+    }
 
     NSMutableArray *pinnedCertificates = [NSMutableArray array];
-    for (NSData *certificateData in @[localCertData]) {
+    for (NSData *certificateData in localCertData) {
         [pinnedCertificates addObject:(__bridge_transfer id)SecCertificateCreateWithData(NULL, (__bridge CFDataRef)certificateData)];
     }
     return pinnedCertificates;
@@ -46,9 +50,11 @@
         NSArray *policies = @[(__bridge_transfer id)SecPolicyCreateSSL(true, (__bridge CFStringRef)domain)];
 
         SecTrustSetPolicies(serverTrust, (__bridge CFArrayRef)policies);
+        // setup
         SecTrustSetAnchorCertificates(serverTrust, (__bridge CFArrayRef)self.pinnedCertificateData);
         SecTrustResultType result;
 
+        // evaluate
         OSStatus errorCode = SecTrustEvaluate(serverTrust, &result);
 
         BOOL evaluatesAsTrusted = (result == kSecTrustResultUnspecified || result == kSecTrustResultProceed);
@@ -111,7 +117,11 @@ RCT_EXPORT_METHOD(fetch:(NSString *)url obj:(NSDictionary *)obj callback:(RCTRes
         }
     }
     if (obj && obj[@"sslPinning"] && obj[@"sslPinning"][@"cert"]) {
-        NSURLSessionSSLPinningDelegate *delegate = [[NSURLSessionSSLPinningDelegate alloc] initWithCertName:obj[@"sslPinning"][@"cert"]];
+        NSURLSessionSSLPinningDelegate *delegate = [[NSURLSessionSSLPinningDelegate alloc] initWithCertNames:@[obj[@"sslPinning"][@"cert"]]];
+        session = [NSURLSession sessionWithConfiguration:self.sessionConfig delegate:delegate delegateQueue:[NSOperationQueue mainQueue]];
+    } else if (obj && obj[@"sslPinning"] && obj[@"sslPinning"][@"certs"]) {
+        // load all certs
+        NSURLSessionSSLPinningDelegate *delegate = [[NSURLSessionSSLPinningDelegate alloc] initWithCertNames:obj[@"sslPinning"][@"certs"]];
         session = [NSURLSession sessionWithConfiguration:self.sessionConfig delegate:delegate delegateQueue:[NSOperationQueue mainQueue]];
     } else {
         session = [NSURLSession sessionWithConfiguration:self.sessionConfig];

--- a/android/src/main/java/com/localz/RNPinch.java
+++ b/android/src/main/java/com/localz/RNPinch.java
@@ -15,9 +15,10 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
-
+import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.UnexpectedNativeTypeException;
 import com.facebook.react.bridge.WritableMap;
+
 import com.localz.pinch.models.HttpRequest;
 import com.localz.pinch.models.HttpResponse;
 import com.localz.pinch.utils.HttpUtil;
@@ -98,7 +99,17 @@ public class RNPinch extends ReactContextBaseJavaModule {
                     request.headers = JsonUtil.convertReadableMapToJson(opts.getMap(OPT_HEADER_KEY));
                 }
                 if (opts.hasKey(OPT_SSL_PINNING_KEY)) {
-                    request.certFilename = opts.getMap(OPT_SSL_PINNING_KEY).getString("cert");
+                    String fileName = opts.getMap(OPT_SSL_PINNING_KEY).getString("cert");
+                    if (fileName != null) {
+                        request.certFilenames = new String[]{fileName};
+                    } else {
+                        ReadableArray certsStrings = opts.getMap(OPT_SSL_PINNING_KEY).getArray("certs");
+                        String[] certs = new String[certsStrings.size()];
+                        for (int i = 0; i < certsStrings.size(); i++) {
+                            certs[i] = certsStrings.getString(i);
+                        }
+                        request.certFilenames = certs;
+                    }
                 }
                 if (opts.hasKey(OPT_TIMEOUT_KEY)) {
                     request.timeout = opts.getInt(OPT_TIMEOUT_KEY);

--- a/android/src/main/java/com/localz/pinch/models/HttpRequest.java
+++ b/android/src/main/java/com/localz/pinch/models/HttpRequest.java
@@ -7,7 +7,7 @@ public class HttpRequest {
     public String method;
     public JSONObject headers;
     public String body;
-    public String certFilename;
+    public String[] certFilenames;
     public int timeout;
 
     private static final int DEFAULT_TIMEOUT = 10000;
@@ -21,12 +21,12 @@ public class HttpRequest {
         this.timeout = DEFAULT_TIMEOUT;
     }
 
-    public HttpRequest(String endpoint, String method, JSONObject headers, String body, String certFilename, int timeout) {
+    public HttpRequest(String endpoint, String method, JSONObject headers, String body, String[] certFilenames, int timeout) {
         this.endpoint = endpoint;
         this.method = method;
         this.headers = headers;
         this.body = body;
-        this.certFilename = certFilename;
+        this.certFilenames = certFilenames;
         this.timeout = timeout;
     }
 }

--- a/android/src/main/java/com/localz/pinch/utils/HttpUtil.java
+++ b/android/src/main/java/com/localz/pinch/utils/HttpUtil.java
@@ -80,8 +80,8 @@ public class HttpUtil {
         String method = request.method.toUpperCase();
 
         connection = (HttpsURLConnection) url.openConnection();
-        if (request.certFilename != null) {
-            connection.setSSLSocketFactory(KeyPinStoreUtil.getInstance(request.certFilename).getContext().getSocketFactory());
+        if (request.certFilenames != null) {
+            connection.setSSLSocketFactory(KeyPinStoreUtil.getInstance(request.certFilenames).getContext().getSocketFactory());
         }
         connection.setRequestMethod(method);
 

--- a/android/src/main/java/com/localz/pinch/utils/KeyPinStoreUtil.java
+++ b/android/src/main/java/com/localz/pinch/utils/KeyPinStoreUtil.java
@@ -19,32 +19,37 @@ import javax.net.ssl.TrustManagerFactory;
 
 public class KeyPinStoreUtil {
 
-    private static HashMap<String, KeyPinStoreUtil> instances = new HashMap<>();
+    private static HashMap<String[], KeyPinStoreUtil> instances = new HashMap<>();
     private SSLContext sslContext = SSLContext.getInstance("TLS");
 
-    public static synchronized KeyPinStoreUtil getInstance(String filename) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
-        if (filename != null && instances.get(filename) == null) {
-            instances.put(filename, new KeyPinStoreUtil(filename));
+    public static synchronized KeyPinStoreUtil getInstance(String[] filenames) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
+        if (filenames != null && instances.get(filenames) == null) {
+            instances.put(filenames, new KeyPinStoreUtil(filenames));
         }
-        return instances.get(filename);
+        return instances.get(filenames);
 
     }
 
-    private KeyPinStoreUtil(String filename) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
+    private KeyPinStoreUtil(String[] filenames) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
         CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        InputStream caInput = new BufferedInputStream(this.getClass().getClassLoader().getResourceAsStream("assets/" + filename + ".cer"));
-        Certificate ca;
-        try {
-            ca = cf.generateCertificate(caInput);
-            System.out.println("ca=" + ((X509Certificate) ca).getSubjectDN());
-        } finally {
-            caInput.close();
-        }
-        // Create a KeyStore containing our trusted CAs
+
+        // Create a KeyStore for our trusted CAs
         String keyStoreType = KeyStore.getDefaultType();
         KeyStore keyStore = KeyStore.getInstance(keyStoreType);
         keyStore.load(null, null);
-        keyStore.setCertificateEntry("ca", ca);
+
+        for (String filename : filenames) {
+            InputStream caInput = new BufferedInputStream(this.getClass().getClassLoader().getResourceAsStream("assets/" + filename + ".cer"));
+            Certificate ca;
+            try {
+                ca = cf.generateCertificate(caInput);
+                System.out.println("ca=" + ((X509Certificate) ca).getSubjectDN());
+            } finally {
+                caInput.close();
+            }
+
+            keyStore.setCertificateEntry(filename, ca);
+        }
 
         // Create a TrustManager that trusts the CAs in our KeyStore
         String tmfAlgorithm = TrustManagerFactory.getDefaultAlgorithm();


### PR DESCRIPTION
This adds support for accepting multiple certificates in the cert chain (in a backwards compatible manner).

Example usage:
```
pinch.fetch('https://my-api.com/v1/endpoint', {
   method: 'post',
   headers: { customHeader: 'customValue' },
   body: '{"firstName": "Jake", "lastName": "Moxey"}',
   timeoutInterval: 10000 // timeout after 10 seconds
   sslPinning: {
    cert: 'cert-file-name', // cert file name without the `.cer`
    certs: ['cert-file-name-1', 'cert-file-name-2'], // optionally specify multiple certificates
   }
 }
```