### PR TITLE
Change the certification format on iOS from 'cer' to 'der'

### DIFF
--- a/RNPinch/RNPinch.m
+++ b/RNPinch/RNPinch.m
@@ -27,7 +27,7 @@
 }
 
 - (NSArray *)pinnedCertificateData {
-    NSString *cerPath = [[NSBundle mainBundle] pathForResource:self.certName ofType:@"cer"];
+    NSString *cerPath = [[NSBundle mainBundle] pathForResource:self.certName ofType:@"der"];
     NSData *localCertData = [NSData dataWithContentsOfFile:cerPath];
 
     NSMutableArray *pinnedCertificates = [NSMutableArray array];


### PR DESCRIPTION
According to the documentation
https://developer.apple.com/documentation/security/1396073-seccertificatecreatewithdata?language=objc
The method 'SecCertificateCreateWithData' only accepts '.der' format. If used with '.cer' a null value is returned.
To transform a '.cer' to '.der', just call: 'openssl x509 -outform der -in filename.cer -out filename.der'