### PR TITLE
Remove dependency on facebook-android-sdk for android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,8 +3,8 @@ apply plugin: "com.android.library"
 import com.android.build.OutputFile
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16
@@ -15,6 +15,5 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.android:facebook-android-sdk:4.+"
     compile "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/android/src/main/java/com/localz/RNPinch.java
+++ b/android/src/main/java/com/localz/RNPinch.java
@@ -8,7 +8,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager.NameNotFoundException;
 
-import com.facebook.internal.BundleJSONConverter;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -105,12 +104,11 @@ public class RNPinch extends ReactContextBaseJavaModule {
                 }
 
                 HttpResponse httpResponse = httpUtil.sendHttpRequest(request);
-                JSONObject jsonHeaders = new JSONObject(httpResponse.headers.toString());
 
                 response.putInt("status", httpResponse.statusCode);
                 response.putString("statusText", httpResponse.statusText);
                 response.putString("bodyString", httpResponse.bodyString);
-                response.putMap("headers", Arguments.fromBundle(BundleJSONConverter.convertToBundle(jsonHeaders)));
+                response.putMap("headers", httpResponse.headers);
 
                 return response;
             } catch(JSONException | IOException | UnexpectedNativeTypeException | KeyStoreException | CertificateException | KeyManagementException | NoSuchAlgorithmException e) {

--- a/android/src/main/java/com/localz/pinch/models/HttpResponse.java
+++ b/android/src/main/java/com/localz/pinch/models/HttpResponse.java
@@ -1,16 +1,16 @@
 package com.localz.pinch.models;
 
-import org.json.JSONObject;
+import com.facebook.react.bridge.WritableMap;
 
 public class HttpResponse {
     public int statusCode;
-    public JSONObject headers;
+    public WritableMap headers;
     public String bodyString;
     public String statusText;
 
     public HttpResponse() {}
 
-    public HttpResponse(int statusCode, JSONObject headers, String bodyString, String statusText) {
+    public HttpResponse(int statusCode, WritableMap headers, String bodyString, String statusText) {
         this.statusCode = statusCode;
         this.headers = headers;
         this.bodyString = bodyString;

--- a/android/src/main/java/com/localz/pinch/utils/HttpUtil.java
+++ b/android/src/main/java/com/localz/pinch/utils/HttpUtil.java
@@ -2,7 +2,10 @@ package com.localz.pinch.utils;
 
 import android.util.Log;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.WritableMap;
+
 import com.localz.pinch.models.HttpRequest;
 import com.localz.pinch.models.HttpResponse;
 
@@ -41,18 +44,14 @@ public class HttpUtil {
         return sb.toString();
     }
 
-    private JSONObject getResponseHeaders(HttpsURLConnection connection) {
-        JSONObject jsonHeaders = new JSONObject();
+    private WritableMap getResponseHeaders(HttpsURLConnection connection) {
+        WritableMap jsonHeaders = Arguments.createMap();
         Map<String, List<String>> headerMap = connection.getHeaderFields();
 
-        try {
-            for (Map.Entry<String, List<String>> entry : headerMap.entrySet()) {
-                if (entry.getKey() != null) {
-                    jsonHeaders.put(entry.getKey(), entry.getValue().get(0));
-                }
+        for (Map.Entry<String, List<String>> entry : headerMap.entrySet()) {
+            if (entry.getKey() != null) {
+                jsonHeaders.putString(entry.getKey(), entry.getValue().get(0));
             }
-        } catch (JSONException e) {
-            Log.e("HTTP Client", "Error retrieving response headers! " + e);
         }
 
         return jsonHeaders;


### PR DESCRIPTION
I might be mistaken, but I believe this requires a dependency on facebook-android-sdk? 

This PR would remove that dependency from the android build and update the code to use only react native builtin functions.