### PR TITLE
Support react-native >= 0.47.0

### DIFF
--- a/android/src/main/java/com/localz/PinchPackage.java
+++ b/android/src/main/java/com/localz/PinchPackage.java
@@ -13,7 +13,6 @@ import java.util.List;
 
 public class PinchPackage implements ReactPackage {
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Fixes #17.

The fix is different to the one suggested in the ticket so as to continue supporting react-native < 0.47.0.

An example of the same fix for a different package is:
https://github.com/oblador/react-native-vector-icons/pull/516

Can we get this merged and a new version released to NPM?