### PR TITLE
React Native 0.4X compatibility issue

### DIFF
--- a/RNPinch/RNPinch.h
+++ b/RNPinch/RNPinch.h
@@ -7,8 +7,14 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "React/RCTBridgeModule.h"
+
+#if __has_include(<React/RCTBridgeModule.h>)
+  #import <React/RCTBridgeModule.h>
+#else
+  #import "RCTBridgeModule.h"
+
 #import "RCTLog.h"
+
 
 @interface RNPinch : NSObject <RCTBridgeModule>
 

--- a/RNPinch/RNPinch.h
+++ b/RNPinch/RNPinch.h
@@ -12,6 +12,7 @@
   #import <React/RCTBridgeModule.h>
 #else
   #import "RCTBridgeModule.h"
+#endif
 
 #import "RCTLog.h"
 

--- a/RNPinch/RNPinch.h
+++ b/RNPinch/RNPinch.h
@@ -7,7 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTBridgeModule.h"
+#import "React/RCTBridgeModule.h"
 #import "RCTLog.h"
 
 @interface RNPinch : NSObject <RCTBridgeModule>

--- a/RNPinch/RNPinch.m
+++ b/RNPinch/RNPinch.m
@@ -7,7 +7,7 @@
 //
 
 #import "RNPinch.h"
-#import "RCTBridge.h"
+#import "React/RCTBridge.h"
 
 @interface RNPinchException : NSException
 @end

--- a/RNPinch/RNPinch.m
+++ b/RNPinch/RNPinch.m
@@ -12,6 +12,7 @@
   #import <React/RCTBridge.h>
 #else
   #import "RCTBridge.h"
+#endif
 
 
 @interface RNPinchException : NSException

--- a/RNPinch/RNPinch.m
+++ b/RNPinch/RNPinch.m
@@ -7,7 +7,12 @@
 //
 
 #import "RNPinch.h"
-#import "React/RCTBridge.h"
+
+#if __has_include(<React/RCTBridge.h>)
+  #import <React/RCTBridge.h>
+#else
+  #import "RCTBridge.h"
+
 
 @interface RNPinchException : NSException
 @end


### PR DESCRIPTION
Hey! 
Due to a compatibility problem with React Native 0.4X, this library cannot be used. I have solved the small problem to be able to use it and I share the solution with you. Now everything works for these versions of React Native.
It's a very useful package.
Best regards, @cdlsaints!