### PR TITLE
 BouncyCastle provider added

### DIFF
--- a/android/src/main/java/com/localz/RNPinch.java
+++ b/android/src/main/java/com/localz/RNPinch.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 
 public class RNPinch extends ReactContextBaseJavaModule {
@@ -122,7 +123,7 @@ public class RNPinch extends ReactContextBaseJavaModule {
                 response.putMap("headers", httpResponse.headers);
 
                 return response;
-            } catch(JSONException | IOException | UnexpectedNativeTypeException | KeyStoreException | CertificateException | KeyManagementException | NoSuchAlgorithmException e) {
+            } catch(JSONException | IOException | UnexpectedNativeTypeException | KeyStoreException | CertificateException | KeyManagementException | NoSuchAlgorithmException | NoSuchProviderException e) {
                 WritableMap error = Arguments.createMap();
                 error.putString("errorMessage", e.toString());
                 return error;

--- a/android/src/main/java/com/localz/pinch/utils/HttpUtil.java
+++ b/android/src/main/java/com/localz/pinch/utils/HttpUtil.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 import java.util.Iterator;
 import java.util.List;
@@ -73,7 +74,7 @@ public class HttpUtil {
     }
 
     private HttpsURLConnection prepareRequest(HttpRequest request)
-            throws IOException, KeyStoreException, CertificateException, KeyManagementException, NoSuchAlgorithmException, JSONException {
+            throws IOException, KeyStoreException, CertificateException, KeyManagementException, NoSuchAlgorithmException, JSONException, NoSuchProviderException {
         HttpsURLConnection connection;
         URL url = new URL(request.endpoint);
         String method = request.method.toUpperCase();
@@ -116,7 +117,7 @@ public class HttpUtil {
     }
 
     public HttpResponse sendHttpRequest(HttpRequest request)
-            throws IOException, KeyStoreException, CertificateException, KeyManagementException, NoSuchAlgorithmException, JSONException {
+            throws IOException, KeyStoreException, CertificateException, KeyManagementException, NoSuchAlgorithmException, JSONException, NoSuchProviderException {
         InputStream responseStream = null;
         HttpResponse response = new HttpResponse();
         HttpsURLConnection connection;

--- a/android/src/main/java/com/localz/pinch/utils/KeyPinStoreUtil.java
+++ b/android/src/main/java/com/localz/pinch/utils/KeyPinStoreUtil.java
@@ -8,6 +8,7 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.Certificate;
+import java.security.NoSuchProviderException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -22,7 +23,7 @@ public class KeyPinStoreUtil {
     private static HashMap<String[], KeyPinStoreUtil> instances = new HashMap<>();
     private SSLContext sslContext = SSLContext.getInstance("TLS");
 
-    public static synchronized KeyPinStoreUtil getInstance(String[] filenames) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
+    public static synchronized KeyPinStoreUtil getInstance(String[] filenames) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException, NoSuchProviderException {
         if (filenames != null && instances.get(filenames) == null) {
             instances.put(filenames, new KeyPinStoreUtil(filenames));
         }
@@ -30,8 +31,8 @@ public class KeyPinStoreUtil {
 
     }
 
-    private KeyPinStoreUtil(String[] filenames) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
-        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+    private KeyPinStoreUtil(String[] filenames) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException, NoSuchProviderException {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509", "BC");
 
         // Create a KeyStore for our trusted CAs
         String keyStoreType = KeyStore.getDefaultType();


### PR DESCRIPTION
According to https://stackoverflow.com/questions/21138485/certificateexception-opensslx509certificatefactoryparsingexception
BC provider needs to be added to parse correctly .cer file.
CertificateFactory.getInstance returns ParsingException if this is not added.
[Reference Link.](https://github.com/localz/react-native-pinch/issues/41)