### PR TITLE
Add support for tls 1.2 on Android 4.1-4.4.

### DIFF
--- a/android/src/main/java/com/localz/pinch/utils/HttpUtil.java
+++ b/android/src/main/java/com/localz/pinch/utils/HttpUtil.java
@@ -1,6 +1,7 @@
 package com.localz.pinch.utils;
 
 import android.util.Log;
+import android.os.Build;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
@@ -27,6 +28,8 @@ import java.util.List;
 import java.util.Map;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+import java.net.HttpURLConnection;
 
 public class HttpUtil {
     private static final String DEFAULT_CONTENT_TYPE = "application/json";
@@ -80,7 +83,11 @@ public class HttpUtil {
 
         connection = (HttpsURLConnection) url.openConnection();
         if (request.certFilenames != null) {
-            connection.setSSLSocketFactory(KeyPinStoreUtil.getInstance(request.certFilenames).getContext().getSocketFactory());
+            SSLSocketFactory socketFactory = KeyPinStoreUtil.getInstance(request.certFilenames).getContext().getSocketFactory();
+            if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT <= 19) {
+                socketFactory = new Tls12SocketFactory(socketFactory);
+            }
+            httpsConnection.setSSLSocketFactory(socketFactory);
         }
         connection.setRequestMethod(method);
 

--- a/android/src/main/java/com/localz/pinch/utils/KeyPinStoreUtil.java
+++ b/android/src/main/java/com/localz/pinch/utils/KeyPinStoreUtil.java
@@ -20,7 +20,7 @@ import javax.net.ssl.TrustManagerFactory;
 public class KeyPinStoreUtil {
 
     private static HashMap<String[], KeyPinStoreUtil> instances = new HashMap<>();
-    private SSLContext sslContext = SSLContext.getInstance("TLS");
+    private SSLContext sslContext = SSLContext.getInstance("TLSv1.2");
 
     public static synchronized KeyPinStoreUtil getInstance(String[] filenames) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
         if (filenames != null && instances.get(filenames) == null) {

--- a/android/src/main/java/com/localz/pinch/utils/Tls12SocketFactory.java
+++ b/android/src/main/java/com/localz/pinch/utils/Tls12SocketFactory.java
@@ -1,0 +1,72 @@
+package com.localz.pinch.utils;
+
+/**
+ * https://github.com/square/okhttp/issues/2372#issuecomment-244807676
+ */
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Enables TLS v1.2 when creating SSLSockets.
+ * <p/>
+ * For some reason, android supports TLS v1.2 from API 16, but enables it by
+ * default only from API 20.
+ * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+ * @see SSLSocketFactory
+ */
+public class Tls12SocketFactory extends SSLSocketFactory {
+    private static final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+    final SSLSocketFactory delegate;
+
+    public Tls12SocketFactory(SSLSocketFactory base) {
+        this.delegate = base;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return patch(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+        return patch(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return patch(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket patch(Socket s) {
+        if (s instanceof SSLSocket) {
+            ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+        }
+        return s;
+    }
+}


### PR DESCRIPTION
ReactNative supports Android >= API level 16, however, similar to the report in https://github.com/square/okhttp/issues/2372, Android has _supported_ TLS 1.2 [since API 16 (android 4.1) but enabled it by default only since API 20 (android "4.4W")](http://developer.android.com/reference/javax/net/ssl/SSLSocket.html). If pinch is used to try to make a connection from one of these devices, it will fail with a `javax.net.ssl.SSLException`.

By testing on the Google Firebase device testing, this fixes the issue for devices at API level 18.

As written, this PR forces the use of TLS 1.2, which probably isn't desired in this library, if this makes sense to move forward, I can explore how to relax that requirement.