### PR TITLE
Plain text certificate support for Android

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ Carthage/Build
 tsConfig.json
 
 android/.idea/
+
+/.idea

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Before you can make requests using SSL pinning, you first need to add your `.cer
 ### Android
 
  - Place your `.cer` files under `src/main/assets/`.
+ 
+ For Android it is also possible to add certificates as plain text. Details below.
 
 ### iOS
 
@@ -150,6 +152,42 @@ pinch.fetch('https://my-api.com/v1/endpoint', {
   sslPinning: {
     cert: 'cert-file-name', // cert file name without the `.cer`
     certs: ['cert-file-name-1', 'cert-file-name-2'], // optionally specify multiple certificates
+  }
+}, (err, res) => {
+  if (err) {
+    console.error(`Whoopsy doodle! Error - ${err}`);
+    return null;
+  }
+  console.log(`We got your response! Response - ${res}`);
+})
+```
+
+### Plain text certificates (for Android)
+
+```javascript
+import pinch from 'react-native-pinch';
+
+pinch.fetch('https://my-api.com/v1/endpoint', {
+  method: 'post',
+  headers: { customHeader: 'customValue' },
+  body: '{"firstName": "Jake", "lastName": "Moxey"}',
+  timeoutInterval: 10000 // timeout after 10 seconds
+  sslPinning: {
+    plainText: true,  // note special parameter
+    cert: {
+      cert: '---- CERTIFICATE AS PLAIN TEXT ----',
+      name: 'cert-name'  // unique name for the certificate
+    },
+    certs: [  // optionally specify multiple certificates
+      {
+        cert: '---- CERTIFICATE AS PLAIN TEXT ----',
+        name: 'cert-name-1'  // unique name for the certificate
+      },
+      {
+        cert: '---- CERTIFICATE AS PLAIN TEXT ----',
+        name: 'cert-name-2'  // unique name for the certificate
+      },
+    ],
   }
 }, (err, res) => {
   if (err) {

--- a/android/src/main/java/com/localz/RNPinch.java
+++ b/android/src/main/java/com/localz/RNPinch.java
@@ -1,8 +1,6 @@
 package com.localz;
 
 import android.os.AsyncTask;
-import android.support.annotation.RequiresPermission;
-import android.util.Log;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageInfo;
 import android.content.pm.ApplicationInfo;
@@ -24,7 +22,6 @@ import com.localz.pinch.utils.HttpUtil;
 import com.localz.pinch.utils.JsonUtil;
 
 import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.IOException;
 import java.security.KeyManagementException;
@@ -38,6 +35,7 @@ public class RNPinch extends ReactContextBaseJavaModule {
     private static final String OPT_HEADER_KEY = "headers";
     private static final String OPT_BODY_KEY = "body";
     private static final String OPT_SSL_PINNING_KEY = "sslPinning";
+    private static final String OPT_SSL_PLAIN_TEXT = "plainText";
     private static final String OPT_TIMEOUT_KEY = "timeoutInterval";
 
     private HttpUtil httpUtil;
@@ -98,16 +96,32 @@ public class RNPinch extends ReactContextBaseJavaModule {
                     request.headers = JsonUtil.convertReadableMapToJson(opts.getMap(OPT_HEADER_KEY));
                 }
                 if (opts.hasKey(OPT_SSL_PINNING_KEY)) {
-                    if (opts.getMap(OPT_SSL_PINNING_KEY).hasKey("cert")) {
-                        String fileName = opts.getMap(OPT_SSL_PINNING_KEY).getString("cert");
-                        request.certFilenames = new String[]{fileName};
-                    } else if (opts.getMap(OPT_SSL_PINNING_KEY).hasKey("certs")) {
-                        ReadableArray certsStrings = opts.getMap(OPT_SSL_PINNING_KEY).getArray("certs");
-                        String[] certs = new String[certsStrings.size()];
-                        for (int i = 0; i < certsStrings.size(); i++) {
-                            certs[i] = certsStrings.getString(i);
+                    if (opts.getMap(OPT_SSL_PINNING_KEY).hasKey(OPT_SSL_PLAIN_TEXT)
+                            && opts.getMap(OPT_SSL_PINNING_KEY).getBoolean(OPT_SSL_PLAIN_TEXT)
+                    ) {
+                        if (opts.getMap(OPT_SSL_PINNING_KEY).hasKey("cert")) {
+                            ReadableMap cert = opts.getMap(OPT_SSL_PINNING_KEY).getMap("cert");
+                            request.certMaps = new ReadableMap[]{cert};
+                        } else if (opts.getMap(OPT_SSL_PINNING_KEY).hasKey("certs")) {
+                            ReadableArray certMaps = opts.getMap(OPT_SSL_PINNING_KEY).getArray("certs");
+                            ReadableMap[] certs = new ReadableMap[certMaps.size()];
+                            for (int i = 0; i < certMaps.size(); i++) {
+                                certs[i] = certMaps.getMap(i);
+                            }
+                            request.certMaps = certs;
                         }
-                        request.certFilenames = certs;
+                    } else {
+                        if (opts.getMap(OPT_SSL_PINNING_KEY).hasKey("cert")) {
+                            String fileName = opts.getMap(OPT_SSL_PINNING_KEY).getString("cert");
+                            request.certFilenames = new String[]{fileName};
+                        } else if (opts.getMap(OPT_SSL_PINNING_KEY).hasKey("certs")) {
+                            ReadableArray certsStrings = opts.getMap(OPT_SSL_PINNING_KEY).getArray("certs");
+                            String[] certs = new String[certsStrings.size()];
+                            for (int i = 0; i < certsStrings.size(); i++) {
+                                certs[i] = certsStrings.getString(i);
+                            }
+                            request.certFilenames = certs;
+                        }
                     }
                 }
                 if (opts.hasKey(OPT_TIMEOUT_KEY)) {

--- a/android/src/main/java/com/localz/pinch/utils/KeyPinStoreUtil.java
+++ b/android/src/main/java/com/localz/pinch/utils/KeyPinStoreUtil.java
@@ -1,5 +1,8 @@
 package com.localz.pinch.utils;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import com.facebook.react.bridge.ReadableMap;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -12,22 +15,21 @@ import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
-import java.util.Map;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 public class KeyPinStoreUtil {
 
-    private static HashMap<String[], KeyPinStoreUtil> instances = new HashMap<>();
+    private static HashMap<String[], KeyPinStoreUtil> instanceStrings = new HashMap<>();
+    private static HashMap<ReadableMap[], KeyPinStoreUtil> instanceMaps = new HashMap<>();
     private SSLContext sslContext = SSLContext.getInstance("TLS");
 
     public static synchronized KeyPinStoreUtil getInstance(String[] filenames) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
-        if (filenames != null && instances.get(filenames) == null) {
-            instances.put(filenames, new KeyPinStoreUtil(filenames));
+        if (filenames != null && instanceStrings.get(filenames) == null) {
+            instanceStrings.put(filenames, new KeyPinStoreUtil(filenames));
         }
-        return instances.get(filenames);
-
+        return instanceStrings.get(filenames);
     }
 
     private KeyPinStoreUtil(String[] filenames) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
@@ -49,6 +51,44 @@ public class KeyPinStoreUtil {
             }
 
             keyStore.setCertificateEntry(filename, ca);
+        }
+
+        // Create a TrustManager that trusts the CAs in our KeyStore
+        String tmfAlgorithm = TrustManagerFactory.getDefaultAlgorithm();
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(tmfAlgorithm);
+        tmf.init(keyStore);
+
+        sslContext.init(null, tmf.getTrustManagers(), null);
+    }
+
+    public static synchronized KeyPinStoreUtil getInstance(ReadableMap[] maps) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
+        if (maps != null && instanceMaps.get(maps) == null) {
+            instanceMaps.put(maps, new KeyPinStoreUtil(maps));
+        }
+        return instanceMaps.get(maps);
+    }
+
+    private KeyPinStoreUtil(ReadableMap[] maps) throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+
+        // Create a KeyStore for our trusted CAs
+        String keyStoreType = KeyStore.getDefaultType();
+        KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+        keyStore.load(null, null);
+
+        for (ReadableMap map : maps) {
+            String cert = map.getString("cert");
+            String name = map.getString("name");
+            InputStream caInput = new ByteArrayInputStream(cert.getBytes(StandardCharsets.UTF_8));
+            Certificate ca;
+            try {
+                ca = cf.generateCertificate(caInput);
+                System.out.println("ca=" + ((X509Certificate) ca).getSubjectDN());
+            } finally {
+                caInput.close();
+            }
+
+            keyStore.setCertificateEntry(name, ca);
         }
 
         // Create a TrustManager that trusts the CAs in our KeyStore


### PR DESCRIPTION
It is pretty handy to have ability to link certificates not only from the app bundle, but on-demand, as plain text.
Please check the README update for details.